### PR TITLE
Update the Note in Step 1

### DIFF
--- a/intune-classic/deploy-use/per-app-vpn-for-android-pulse-secure.md
+++ b/intune-classic/deploy-use/per-app-vpn-for-android-pulse-secure.md
@@ -48,7 +48,7 @@ After you deploy the policy to your Android device or user groups, users should 
 
 > [!NOTE]
 >
-> Take note of the “VPN Connection name (displayed to users):” value you specify when creating the VPN profile. This will be needed in the next step. For example, MyAppVpnProfile.
+> Take note of the **VPN Connection name (displayed to users):** value you specify when creating the VPN profile. This will be needed in the next step. For example, MyAppVpnProfile.
 
 ### Step 2: Create a custom configuration policy
 

--- a/intune-classic/deploy-use/per-app-vpn-for-android-pulse-secure.md
+++ b/intune-classic/deploy-use/per-app-vpn-for-android-pulse-secure.md
@@ -48,7 +48,7 @@ After you deploy the policy to your Android device or user groups, users should 
 
 > [!NOTE]
 >
-> Take note of the VPN profile name to use in the next step. For example, MyAppVpnProfile.
+> Take note of the “VPN Connection name (displayed to users):” value you specify when creating the VPN profile. This will be needed in the next step. For example, MyAppVpnProfile.
 
 ### Step 2: Create a custom configuration policy
 


### PR DESCRIPTION
Update the Note in Step 1 to clarify and expand the definition of what exactly "VPN Profile name" means wrt the actual field used during the configuration of the VPN profile. This will prevent support calls when customers use the wrong name when configuring the OMA-URI below.