### PR TITLE
Update the Note in Step 1

### DIFF
--- a/intune/android-pulse-secure-per-app-vpn.md
+++ b/intune/android-pulse-secure-per-app-vpn.md
@@ -53,7 +53,7 @@ After you assign the policy to your Android device or user groups, users should 
 5. From the **Profile type** drop-down list, choose **VPN**.
 3. Choose **Settings** > **Configure** and then configure the VPN profile as per the settings in [How to configure VPN settings](vpn-settings-configure.md) and [Intune VPN settings for Android devices](vpn-settings-android.md).
 
-Take note of the “Connection Name” value you specify when creating the VPN profile. This will be needed in the next step. For example, **MyAppVpnProfile**.
+Take note of the **Connection Name** value you specify when creating the VPN profile. This will be needed in the next step. For example, **MyAppVpnProfile**.
 
 ## Step 2: Create a custom configuration policy
 

--- a/intune/android-pulse-secure-per-app-vpn.md
+++ b/intune/android-pulse-secure-per-app-vpn.md
@@ -1,7 +1,8 @@
 ---
 # required metadata
 
-title: Per-app VPN profile for Android - Pulse SecuretitleSuffix: "Intune Azure preview"
+title: Per-app VPN profile for Android - Pulse Secure
+titleSuffix: "Intune Azure preview"
 description: "Intune Azure preview: Learn how to create a per-app VPN profile for Android devices managed by Intune."
 keywords:
 author: robstackmsft
@@ -52,7 +53,7 @@ After you assign the policy to your Android device or user groups, users should 
 5. From the **Profile type** drop-down list, choose **VPN**.
 3. Choose **Settings** > **Configure** and then configure the VPN profile as per the settings in [How to configure VPN settings](vpn-settings-configure.md) and [Intune VPN settings for Android devices](vpn-settings-android.md).
 
-Take note of the VPN profile name to use in the next step. For example, **MyAppVpnProfile**.
+Take note of the “Connection Name” value you specify when creating the VPN profile. This will be needed in the next step. For example, **MyAppVpnProfile**.
 
 ## Step 2: Create a custom configuration policy
 


### PR DESCRIPTION
Update the Note in Step 1 to clarify and expand the definition of what exactly "VPN Profile name" means wrt the actual field used during the configuration of the VPN profile. This will prevent support calls when customers use the wrong name when configuring the OMA-URI below.

This is specific to the Azure portal. A separate pull request for updating the same Note for the Classic Portal has been opened here: https://github.com/Microsoft/IntuneDocs/pull/472