### PR TITLE
iTunes app shouldn't be blocked for user based VPP

### DIFF
--- a/intune/vpp-apps-ios.md
+++ b/intune/vpp-apps-ios.md
@@ -8,7 +8,7 @@ keywords:
 author: robstackmsft
 ms.author: robstack
 manager: angrobe
-ms.date: 05/12/2017
+ms.date: 06/18/2017
 ms.topic: article
 ms.prod:
 ms.service: microsoft-intune
@@ -89,6 +89,6 @@ When you assign the app as a **Required** installation, each user who installs t
 
 To reclaim a license, you must change the assignment action to **Uninstall**. The license will be reclaimed after the app is uninstalled.
 
-When a user with an eligible device first tries to install a VPP app, they will be asked to join the Apple Volume Purchase program. They must do this before the app installation proceeds. Please note that the invitation to join the Apple Volume Purchase program requires the user to be able to use the iTunes app on the iOS device. If you have set a custom configuration policy to disable the iTunes Store app, user based licensing for VPP apps will not work. The solution is to either allow the iTunes app by removing the policy, or use Device Based licensing.
+When a user with an eligible device first tries to install a VPP app, they will be asked to join the Apple Volume Purchase program. They must do this before the app installation proceeds. The invitation to join the Apple Volume Purchase program requires that the user can use the iTunes app on the iOS device. If you have set a custom configuration policy to disable the iTunes Store app, user-based licensing for VPP apps does not work. The solution is to either allow the iTunes app by removing the policy, or use device-based licensing.
 
 When you assign a VPP app as Available, the app content and license are assigned directly from the app store.

--- a/intune/vpp-apps-ios.md
+++ b/intune/vpp-apps-ios.md
@@ -89,6 +89,6 @@ When you assign the app as a **Required** installation, each user who installs t
 
 To reclaim a license, you must change the assignment action to **Uninstall**. The license will be reclaimed after the app is uninstalled.
 
-When a user with an eligible device first tries to install a VPP app, they will be asked to join the Apple Volume Purchase program. They must do this before the app installation proceeds.
+When a user with an eligible device first tries to install a VPP app, they will be asked to join the Apple Volume Purchase program. They must do this before the app installation proceeds. Please note that the invitation to join the Apple Volume Purchase program requires the user to be able to use the iTunes app on the iOS device. If you have set a custom configuration policy to disable the iTunes Store app, user based licensing for VPP apps will not work. The solution is to either allow the iTunes app by removing the policy, or use Device Based licensing.
 
 When you assign a VPP app as Available, the app content and license are assigned directly from the app store.


### PR DESCRIPTION
Clarify the documentation by stating that adding an app restrictions policy to prevent iTunes app will make iOS VPP User licensing to not work. The solution is to remove such a policy or use device based VPP licensing.