### PR TITLE
Remove Wallet as example from hide apps section

### DIFF
--- a/intune/configuration/device-restrictions-ios.md
+++ b/intune/configuration/device-restrictions-ios.md
@@ -410,7 +410,7 @@ Applies to devices running iOS 9.3 or newer.
 
   - **Hidden apps**: Enter a list of apps that are hidden from users. Users can't view, or open these apps.
   
-    Apple prevents hiding some native apps. For example, you can't hide the **Settings** or **Wallet** apps on the device. [Delete built-in Apple apps](https://support.apple.com/HT208094) lists the apps that can be hidden.
+    Apple prevents hiding some native apps. For example, you can't hide the **Settings** app on the device. [Delete built-in Apple apps](https://support.apple.com/HT208094) lists the apps that can be hidden.
   
   - **Visible apps**: Enter a list of apps that users can view and launch. No other apps can be viewed or launched.
 


### PR DESCRIPTION
Through some feedback from the field working with a customer, it was found that the Wallet app CAN be hidden on iOS devices. Our docs stated that the Wallet app cannot be hidden as an example - this update removes that example and keeps the Settings app as the only example of apps that cannot be hidden.